### PR TITLE
Fix macOS NSWindow error by using matplotlib 'Agg' backend

### DIFF
--- a/detail_daemon_node.py
+++ b/detail_daemon_node.py
@@ -4,6 +4,13 @@ from __future__ import annotations
 
 import io
 
+# Trying matplotlib NSWindow warning workaround on macOS
+import platform
+
+if platform.system() == 'Darwin':  # Check if running on macOS
+    import matplotlib
+    matplotlib.use('Agg')  # Set non-GUI backend to avoid crashes
+
 import matplotlib.pyplot as plt
 import numpy as np
 import torch


### PR DESCRIPTION
## Summary
- Fixes the NSWindow error on macOS caused by Matplotlib's GUI backend.
- Uses 'Agg' backend on macOS to prevent crashes when running in worker threads.

## Why?
- Fixes issue where ComfyUI crashes with: 
  "NSWindow should only be instantiated on the main thread!"
- Ensures compatibility with Mac M1/M2 chips.

## Changes
- Added a platform check (`platform.system() == 'Darwin'`).
- Set Matplotlib backend to 'Agg' for macOS.

## Testing
- Tested on macOS M1 Max, works without crashes.
